### PR TITLE
Windows requires ";" separted path

### DIFF
--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -6,6 +6,7 @@
 import * as path from "path";
 import { workspace, ExtensionContext } from "vscode";
 import vscode = require("vscode");
+import os = require('os');
 
 import {
   LanguageClient,
@@ -85,7 +86,11 @@ export function activate(context: ExtensionContext) {
   let serverEnv = process.env;
 
   if (cfgCompilerPath) {
-    serverEnv.PATH = cfgCompilerPath + ":" + serverEnv.PATH;
+	if ( os.platform() == "win32" ) {
+		serverEnv.PATH = cfgCompilerPath + ";" + serverEnv.PATH;
+	} else {
+		serverEnv.PATH = cfgCompilerPath + ":" + serverEnv.PATH;
+	}
     console.log("Adding " + cfgCompilerPath + " to the server startup path");
   }
 

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -86,11 +86,11 @@ export function activate(context: ExtensionContext) {
   let serverEnv = process.env;
 
   if (cfgCompilerPath) {
-	if ( os.platform() == "win32" ) {
-		serverEnv.PATH = cfgCompilerPath + ";" + serverEnv.PATH;
-	} else {
-		serverEnv.PATH = cfgCompilerPath + ":" + serverEnv.PATH;
-	}
+    if ( os.platform() == "win32" ) {
+      serverEnv.PATH = cfgCompilerPath + ";" + serverEnv.PATH;
+    } else {
+      serverEnv.PATH = cfgCompilerPath + ":" + serverEnv.PATH;
+    }
     console.log("Adding " + cfgCompilerPath + " to the server startup path");
   }
 


### PR DESCRIPTION
On Windows the compilerPath parameter does not work as expected.
Indeed Windows requires ";" separted path instead of ":"
